### PR TITLE
docs: remove locales references

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Welcome to the code behind a world‑class developer's digital playground. It's 
 - **TypeScript**—because type safety is the best safety
 - **Tailwind CSS** & **shadcn/ui** for styling with flair
 - Animations courtesy of **Framer Motion**, **Magic UI**, `rough-notation`, and even `canvas-confetti`
-- Localization ready via the `locales/` directory
 
 ## Getting Started
 
@@ -28,7 +27,6 @@ src/
 ├─ data/            # copy and resume info
 ├─ hooks/           # reusable hooks
 ├─ lib/             # utilities
-├─ locales/         # translations
 ├─ pages/           # route-level components
 └─ sections/        # big, reusable page sections
 ```


### PR DESCRIPTION
## Summary
- remove mention of `locales` directory from documentation now that the site only targets English

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b99cd0db2483319240c5b252199413