### PR TITLE
feat: revamp header icons

### DIFF
--- a/src/components/ui/navbar/header.tsx
+++ b/src/components/ui/navbar/header.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 import { DATA } from '@/data/resume.tsx';
 import { Dock, DockIcon } from '@/components/magicui/dock.tsx';
-import { Terminal } from 'lucide-react';
+import { Folder, Terminal } from 'lucide-react';
 import {
   Sheet,
   SheetContent,
@@ -17,8 +17,9 @@ export function Header(props: { onClick: () => void }) {
   return (
     <header className="sticky top-0 z-50 w-full border-b border-white/10 bg-gray-950/80 backdrop-blur">
       <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-3">
-        <Link to="/" className="flex items-center gap-3">
-          <span className="text-sm font-semibold">{DATA.name}</span>
+        <Link to="/" className="flex items-center gap-2 font-mono text-sm font-semibold">
+          <Terminal className="h-4 w-4 text-green-400" />
+          <span>{DATA.name}</span>
         </Link>
         <Breadcrumb />
         {/* Desktop dock nav */}
@@ -30,7 +31,7 @@ export function Header(props: { onClick: () => void }) {
                 onClick={props.onClick}
                 className="px-2 py-1 cursor-pointer"
               >
-                <Terminal className="h-4 w-4" />
+                <Folder className="h-4 w-4" />
               </button>
             </DockIcon>
           </Dock>
@@ -41,7 +42,7 @@ export function Header(props: { onClick: () => void }) {
           <Sheet>
             <SheetTrigger asChild>
               <Button variant="ghost" size="icon">
-                <Terminal className="h-5 w-5" />
+                <Folder className="h-5 w-5" />
               </Button>
             </SheetTrigger>
             <SheetContent

--- a/src/components/ui/navbar/mobilenav-file-tree.tsx
+++ b/src/components/ui/navbar/mobilenav-file-tree.tsx
@@ -14,126 +14,183 @@ export function MobileNavFileTree() {
         <Folder element="src" value="src">
           <Folder element="assets" value="assets" />
           <Folder element="components" value="components">
-            <Folder element="magicui" value="magicui">
-              <File value="f_animated-grid-pattern">
-                <span className="block px-1 py-0.5">animated-grid-pattern.tsx</span>
-              </File>
-              <File value="f_blur-fade-text">
-                <span className="block px-1 py-0.5">blur-fade-text.tsx</span>
-              </File>
-              <File value="f_blur-fade">
-                <span className="block px-1 py-0.5">blur-fade.tsx</span>
-              </File>
-              <File value="f_dock">
-                <span className="block px-1 py-0.5">dock.tsx</span>
-              </File>
-              <File value="f_dot-pattern">
-                <span className="block px-1 py-0.5">dot-pattern.tsx</span>
-              </File>
-              <File value="f_file-tree">
-                <span className="block px-1 py-0.5">file-tree.tsx</span>
-              </File>
-              <File value="f_flickering-grid">
-                <span className="block px-1 py-0.5">flickering-grid.tsx</span>
-              </File>
-              <File value="f_globe">
-                <span className="block px-1 py-0.5">globe.tsx</span>
-              </File>
-              <File value="f_grid-beams">
-                <span className="block px-1 py-0.5">grid-beams.tsx</span>
-              </File>
-              <File value="f_grid-pattern">
-                <span className="block px-1 py-0.5">grid-pattern.tsx</span>
-              </File>
-              <File value="f_interactive-grid-pattern">
-                <span className="block px-1 py-0.5">interactive-grid-pattern.tsx</span>
-              </File>
-              <File value="f_neon-gradient-card">
-                <span className="block px-1 py-0.5">neon-gradient-card.tsx</span>
-              </File>
-              <File value="f_retro-grid">
-                <span className="block px-1 py-0.5">retro-grid.tsx</span>
-              </File>
-              <File value="f_ripple">
-                <span className="block px-1 py-0.5">ripple.tsx</span>
-              </File>
-              <File value="f_shimmer-button">
-                <span className="block px-1 py-0.5">shimmer-button.tsx</span>
-              </File>
-              <File value="f_terminal">
-                <span className="block px-1 py-0.5">terminal.tsx</span>
-              </File>
-              <File value="f_warp-background">
-                <span className="block px-1 py-0.5">warp-background.tsx</span>
-              </File>
-            </Folder>
-            <Folder element="ui" value="ui">
-              <Folder element="navbar" value="navbar">
-                <File value="f_draggable-explorer">
-                  <span className="block px-1 py-0.5">draggable-explorer.tsx</span>
+              <Folder element="magicui" value="magicui">
+                <File value="f_animated-grid-pattern">
+                  <span className="block px-1 py-0.5">animated-grid-pattern.tsx</span>
                 </File>
-                <File value="f_header">
-                  <span className="block px-1 py-0.5">header.tsx</span>
+                <File value="f_aurora-text">
+                  <span className="block px-1 py-0.5">aurora-text.tsx</span>
                 </File>
-                <File value="f_mobilenav-file-tree">
-                  <span className="block px-1 py-0.5">mobilenav-file-tree.tsx</span>
+                <File value="f_blur-fade-text">
+                  <span className="block px-1 py-0.5">blur-fade-text.tsx</span>
+                </File>
+                <File value="f_blur-fade">
+                  <span className="block px-1 py-0.5">blur-fade.tsx</span>
+                </File>
+                <File value="f_confetti">
+                  <span className="block px-1 py-0.5">confetti.tsx</span>
+                </File>
+                <File value="f_cool-mode">
+                  <span className="block px-1 py-0.5">cool-mode.tsx</span>
+                </File>
+                <File value="f_dock">
+                  <span className="block px-1 py-0.5">dock.tsx</span>
+                </File>
+                <File value="f_dot-pattern">
+                  <span className="block px-1 py-0.5">dot-pattern.tsx</span>
+                </File>
+                <File value="f_file-tree">
+                  <span className="block px-1 py-0.5">file-tree.tsx</span>
+                </File>
+                <File value="f_flickering-grid">
+                  <span className="block px-1 py-0.5">flickering-grid.tsx</span>
+                </File>
+                <File value="f_globe">
+                  <span className="block px-1 py-0.5">globe.tsx</span>
+                </File>
+                <File value="f_grid-beams">
+                  <span className="block px-1 py-0.5">grid-beams.tsx</span>
+                </File>
+                <File value="f_grid-pattern">
+                  <span className="block px-1 py-0.5">grid-pattern.tsx</span>
+                </File>
+                <File value="f_highlighter">
+                  <span className="block px-1 py-0.5">highlighter.tsx</span>
+                </File>
+                <File value="f_interactive-grid-pattern">
+                  <span className="block px-1 py-0.5">interactive-grid-pattern.tsx</span>
+                </File>
+                <File value="f_marquee">
+                  <span className="block px-1 py-0.5">marquee.tsx</span>
+                </File>
+                <File value="f_neon-gradient-card">
+                  <span className="block px-1 py-0.5">neon-gradient-card.tsx</span>
+                </File>
+                <File value="f_particles">
+                  <span className="block px-1 py-0.5">particles.tsx</span>
+                </File>
+                <File value="f_rainbow-button">
+                  <span className="block px-1 py-0.5">rainbow-button.tsx</span>
+                </File>
+                <File value="f_retro-grid">
+                  <span className="block px-1 py-0.5">retro-grid.tsx</span>
+                </File>
+                <File value="f_ripple">
+                  <span className="block px-1 py-0.5">ripple.tsx</span>
+                </File>
+                <File value="f_scratch-to-reveal">
+                  <span className="block px-1 py-0.5">scratch-to-reveal.tsx</span>
+                </File>
+                <File value="f_shimmer-button">
+                  <span className="block px-1 py-0.5">shimmer-button.tsx</span>
+                </File>
+                <File value="f_terminal">
+                  <span className="block px-1 py-0.5">terminal.tsx</span>
+                </File>
+                <File value="f_typing-animation">
+                  <span className="block px-1 py-0.5">typing-animation.tsx</span>
+                </File>
+                <File value="f_warp-background">
+                  <span className="block px-1 py-0.5">warp-background.tsx</span>
                 </File>
               </Folder>
-              <File value="f_accordion">
-                <span className="block px-1 py-0.5">accordion.tsx</span>
+              <Folder element="ui" value="ui">
+                <Folder element="navbar" value="navbar">
+                  <File value="f_breadcrumb">
+                    <span className="block px-1 py-0.5">breadcrumb.tsx</span>
+                  </File>
+                  <File value="f_draggable-explorer">
+                    <span className="block px-1 py-0.5">draggable-explorer.tsx</span>
+                  </File>
+                  <File value="f_header">
+                    <span className="block px-1 py-0.5">header.tsx</span>
+                  </File>
+                  <File value="f_mobilenav-file-tree">
+                    <span className="block px-1 py-0.5">mobilenav-file-tree.tsx</span>
+                  </File>
+                </Folder>
+                <File value="f_accordion">
+                  <span className="block px-1 py-0.5">accordion.tsx</span>
+                </File>
+                <File value="f_avatar">
+                  <span className="block px-1 py-0.5">avatar.tsx</span>
+                </File>
+                <File value="f_badge">
+                  <span className="block px-1 py-0.5">badge.tsx</span>
+                </File>
+                <File value="f_button">
+                  <span className="block px-1 py-0.5">button.tsx</span>
+                </File>
+                <File value="f_card">
+                  <span className="block px-1 py-0.5">card.tsx</span>
+                </File>
+                <File value="f_dialog">
+                  <span className="block px-1 py-0.5">dialog.tsx</span>
+                </File>
+                <File value="f_input">
+                  <span className="block px-1 py-0.5">input.tsx</span>
+                </File>
+                <File value="f_label">
+                  <span className="block px-1 py-0.5">label.tsx</span>
+                </File>
+                <File value="f_popover">
+                  <span className="block px-1 py-0.5">popover.tsx</span>
+                </File>
+                <File value="f_progress">
+                  <span className="block px-1 py-0.5">progress.tsx</span>
+                </File>
+                <File value="f_scroll-area">
+                  <span className="block px-1 py-0.5">scroll-area.tsx</span>
+                </File>
+                <File value="f_separator">
+                  <span className="block px-1 py-0.5">separator.tsx</span>
+                </File>
+                <File value="f_sheet">
+                  <span className="block px-1 py-0.5">sheet.tsx</span>
+                </File>
+                <File value="f_textarea">
+                  <span className="block px-1 py-0.5">textarea.tsx</span>
+                </File>
+                <File value="f_tooltip">
+                  <span className="block px-1 py-0.5">tooltip.tsx</span>
+                </File>
+              </Folder>
+              <File value="f_constants">
+                <span className="block px-1 py-0.5">constants.ts</span>
               </File>
-              <File value="f_avatar">
-                <span className="block px-1 py-0.5">avatar.tsx</span>
+              <File value="f_error-boundary">
+                <span className="block px-1 py-0.5">error-boundary.tsx</span>
               </File>
-              <File value="f_badge">
-                <span className="block px-1 py-0.5">badge.tsx</span>
+              <File value="f_icons">
+                <span className="block px-1 py-0.5">icons.tsx</span>
               </File>
-              <File value="f_button">
-                <span className="block px-1 py-0.5">button.tsx</span>
+              <File value="f_joke-dialog">
+                <span className="block px-1 py-0.5">joke-dialog.tsx</span>
               </File>
-              <File value="f_card">
-                <span className="block px-1 py-0.5">card.tsx</span>
+              <File value="f_loading-screen">
+                <span className="block px-1 py-0.5">loading-screen.tsx</span>
               </File>
-              <File value="f_dialog">
-                <span className="block px-1 py-0.5">dialog.tsx</span>
+              <File value="f_mode-toggle">
+                <span className="block px-1 py-0.5">mode-toggle.tsx</span>
               </File>
-              <File value="f_popover">
-                <span className="block px-1 py-0.5">popover.tsx</span>
+              <File value="f_oss-card">
+                <span className="block px-1 py-0.5">oss-card.tsx</span>
               </File>
-              <File value="f_scroll-area">
-                <span className="block px-1 py-0.5">scroll-area.tsx</span>
+              <File value="f_theme-provider">
+                <span className="block px-1 py-0.5">theme-provider.tsx</span>
               </File>
-              <File value="f_separator">
-                <span className="block px-1 py-0.5">separator.tsx</span>
+              <File value="f_timeline-card">
+                <span className="block px-1 py-0.5">timeline-card.tsx</span>
               </File>
-              <File value="f_sheet">
-                <span className="block px-1 py-0.5">sheet.tsx</span>
+              <File value="f_timeline-globe">
+                <span className="block px-1 py-0.5">timeline-globe.tsx</span>
               </File>
-              <File value="f_tooltip">
-                <span className="block px-1 py-0.5">tooltip.tsx</span>
+              <File value="f_timeline-roulette">
+                <span className="block px-1 py-0.5">timeline-roulette.tsx</span>
               </File>
-            </Folder>
-            <File value="f_constants">
-              <span className="block px-1 py-0.5">constants.ts</span>
-            </File>
-            <File value="f_icons">
-              <span className="block px-1 py-0.5">icons.tsx</span>
-            </File>
-            <File value="f_loading-screen">
-              <span className="block px-1 py-0.5">loading-screen.tsx</span>
-            </File>
-            <File value="f_mode-toggle">
-              <span className="block px-1 py-0.5">mode-toggle.tsx</span>
-            </File>
-            <File value="f_oss-card">
-              <span className="block px-1 py-0.5">oss-card.tsx</span>
-            </File>
-            <File value="f_theme-provider">
-              <span className="block px-1 py-0.5">theme-provider.tsx</span>
-            </File>
-            <File value="f_timeline-card">
-              <span className="block px-1 py-0.5">timeline-card.tsx</span>
-            </File>
+              <File value="f_virus-scan-dialog">
+                <span className="block px-1 py-0.5">virus-scan-dialog.tsx</span>
+              </File>
           </Folder>
           <Folder element="data" value="data">
             <File value="f_copy">
@@ -165,28 +222,37 @@ export function MobileNavFileTree() {
               <span className="block px-1 py-0.5">utils.ts</span>
             </File>
           </Folder>
-          <Folder element="pages" value="pages">
-            <File value="f_Home">
-              <Link to="/" className="block px-1 py-0.5 flex items-center gap-1">
-                <LinkIcon className="w-3 h-3" />
-                Home.tsx
-              </Link>
-            </File>
-            <File value="f_OpenSource">
-              <Link to="/oss" className="block px-1 py-0.5 flex items-center gap-1">
-                <LinkIcon className="w-3 h-3" />
-                OpenSource.tsx
-              </Link>
-            </File>
-          </Folder>
-          <Folder element="sections" value="sections">
-            <File value="f_footer">
-              <span className="block px-1 py-0.5">footer.tsx</span>
-            </File>
-            <File value="f_oss-highlights">
-              <span className="block px-1 py-0.5">oss-highlights.tsx</span>
-            </File>
-          </Folder>
+            <Folder element="pages" value="pages">
+              <File value="f_Contact">
+                <Link to="/contact" className="block px-1 py-0.5 flex items-center gap-1">
+                  <LinkIcon className="w-3 h-3" />
+                  Contact.tsx
+                </Link>
+              </File>
+              <File value="f_Home">
+                <Link to="/" className="block px-1 py-0.5 flex items-center gap-1">
+                  <LinkIcon className="w-3 h-3" />
+                  Home.tsx
+                </Link>
+              </File>
+              <File value="f_OpenSource">
+                <Link to="/oss" className="block px-1 py-0.5 flex items-center gap-1">
+                  <LinkIcon className="w-3 h-3" />
+                  OpenSource.tsx
+                </Link>
+              </File>
+            </Folder>
+            <Folder element="sections" value="sections">
+              <File value="f_experience-roulette">
+                <span className="block px-1 py-0.5">experience-roulette.tsx</span>
+              </File>
+              <File value="f_footer">
+                <span className="block px-1 py-0.5">footer.tsx</span>
+              </File>
+              <File value="f_oss-highlights">
+                <span className="block px-1 py-0.5">oss-highlights.tsx</span>
+              </File>
+            </Folder>
           <File value="f_App">
             <span className="block px-1 py-0.5">App.tsx</span>
           </File>


### PR DESCRIPTION
## Summary
- place dev Terminal icon beside the "Andres Suarez" label for a terminal-like vibe
- swap explorer toggle to use a Folder icon on desktop dock and mobile menu
- sync menu tree with new pages, sections, and components

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9f6deb4708331814b813045bd35e2