### PR TITLE
feat: use terminal font and unified nav

### DIFF
--- a/src/components/ui/navbar/breadcrumb.tsx
+++ b/src/components/ui/navbar/breadcrumb.tsx
@@ -14,7 +14,7 @@ export function Breadcrumb() {
   };
 
   return (
-    <div className="hidden md:flex items-center gap-2 text-sm text-gray-400">
+    <div className="flex items-center gap-2 text-sm text-gray-400 font-mono">
       <span className="text-cyan-400">➜</span>
       <span>{formatPath(path)}</span>
     </div>

--- a/src/components/ui/navbar/draggable-explorer.tsx
+++ b/src/components/ui/navbar/draggable-explorer.tsx
@@ -71,7 +71,7 @@ export function DraggableExplorer({
     <div
       ref={ref}
       style={style}
-      className="z-[100] rounded-lg border border-white/10 bg-gray-950/95 backdrop-blur shadow-2xl"
+      className="z-[100] rounded-lg border border-white/10 bg-gray-950/95 backdrop-blur shadow-2xl font-mono"
     >
       {/* Titlebar */}
       <div
@@ -91,7 +91,7 @@ export function DraggableExplorer({
 
       {/* Content */}
       <div className="h-[calc(100%-32px)] overflow-hidden">
-        <div className="h-full overflow-auto p-2 text-sm">
+        <div className="h-full overflow-auto p-2 text-sm font-mono">
           <MobileNavFileTree />
         </div>
       </div>

--- a/src/components/ui/navbar/header.tsx
+++ b/src/components/ui/navbar/header.tsx
@@ -2,65 +2,28 @@ import { Link } from 'react-router-dom';
 import { DATA } from '@/data/resume.tsx';
 import { Dock, DockIcon } from '@/components/magicui/dock.tsx';
 import { Folder, Terminal } from 'lucide-react';
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from '@/components/ui/sheet.tsx';
-import { Button } from '@/components/ui/button.tsx';
-import { MobileNavFileTree } from './mobilenav-file-tree';
 import { Breadcrumb } from './breadcrumb';
 
 export function Header(props: { onClick: () => void }) {
   return (
-    <header className="sticky top-0 z-50 w-full border-b border-white/10 bg-gray-950/80 backdrop-blur">
+    <header className="sticky top-0 z-50 w-full border-b border-white/10 bg-gray-950/80 backdrop-blur font-mono">
       <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-3">
-        <Link to="/" className="flex items-center gap-2 font-mono text-sm font-semibold">
+        <Link to="/" className="flex items-center gap-2 text-sm font-semibold">
           <Terminal className="h-4 w-4 text-green-400" />
           <span>{DATA.name}</span>
         </Link>
         <Breadcrumb />
-        {/* Desktop dock nav */}
-        <div className="hidden md:block">
-          <Dock>
-            <DockIcon>
-              <button
-                aria-label="Toggle Explorer"
-                onClick={props.onClick}
-                className="px-2 py-1 cursor-pointer"
-              >
-                <Folder className="h-4 w-4" />
-              </button>
-            </DockIcon>
-          </Dock>
-        </div>
-        {/* Global hamburger: mobile opens Sheet, desktop opens draggable Explorer */}
-        {/* Mobile (Sheet) */}
-        <div className="md:hidden">
-          <Sheet>
-            <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <Folder className="h-5 w-5" />
-              </Button>
-            </SheetTrigger>
-            <SheetContent
-              side="right"
-              className="bg-gray-950 text-white border-white/10 w-[90vw] max-w-sm p-0"
+        <Dock>
+          <DockIcon>
+            <button
+              aria-label="Toggle Explorer"
+              onClick={props.onClick}
+              className="px-2 py-1 cursor-pointer"
             >
-              <SheetHeader className="p-4">
-                <SheetTitle className="text-white">Explorer</SheetTitle>
-              </SheetHeader>
-              <div className="px-2 pb-4">
-                <MobileNavFileTree />
-              </div>
-            </SheetContent>
-          </Sheet>
-        </div>
-
-        {/* Desktop (Draggable/Resizable window like WebStorm) */}
-        {/* Removed duplicate explorer toggle button, now in Dock */}
+              <Folder className="h-4 w-4" />
+            </button>
+          </DockIcon>
+        </Dock>
       </div>
     </header>
   );

--- a/src/components/ui/navbar/mobilenav-file-tree.tsx
+++ b/src/components/ui/navbar/mobilenav-file-tree.tsx
@@ -6,7 +6,7 @@ export function MobileNavFileTree() {
   return (
     <div className="relative flex h-full flex-col overflow-hidden">
       <Tree
-        className="overflow-auto p-2 text-sm select-none"
+        className="overflow-auto p-2 text-sm select-none font-mono"
         initialSelectedId="pages"
         initialExpandedItems={['src', 'pages']}
         aria-label="Site sections explorer"


### PR DESCRIPTION
## Summary
- use terminal-like font across header, breadcrumbs, and navigation file tree
- replace mobile sheet nav with draggable explorer via dock
- ensure draggable explorer and menus use monospace styling

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9fca94f0c8331ae9fa33863b09627