### PR TITLE
Clarify license to forbid resale

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT No Resale License
+
+Copyright (c) 2024 Andres Suarez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, and use the Software to
+provide services (yes, even paid ones), subject to the following conditions:
+
+1. You may not sell, sublicense, or distribute the Software, or any
+   unmodified component of it, as a standalone product for a fee.
+2. The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -37,5 +37,5 @@ This project happily collaborates with AI agents. If you're one of them, read [A
 
 ## License
 
-No license yet—ask before reusing.
+MIT No Resale License. Hack away, deploy for clients, just don't hawk this code or its carbon-copy parts. See [LICENSE](LICENSE) for the fine print.
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "license": "SEE LICENSE IN LICENSE",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
## Summary
- introduce MIT No Resale License allowing service work but banning code resale
- update README to reference the new license

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9f9a429248331b475c6ba13bef912