### PR TITLE
Enhance project cards and dialog

### DIFF
--- a/src/components/ProjectsGrid.tsx
+++ b/src/components/ProjectsGrid.tsx
@@ -1,17 +1,24 @@
 
 import { useMemo, useState } from 'react';
 import { TIMELINE_DATA } from '@/data/timeline';
-import { flattenTimeline } from '@/lib/timeline';
-import { Card, CardContent } from '@/components/ui/card';
+import { flattenTimeline, type FlattenedItem } from '@/lib/timeline';
+import { Badge } from '@/components/ui/badge';
+import { NeonGradientCard } from '@/components/magicui/neon-gradient-card';
+import { Ripple } from '@/components/magicui/ripple';
 import { cn } from '@/lib/utils';
 import ProjectDialog from '@/components/project-dialog';
 
 export default function ProjectsGrid() {
-  const items = useMemo(() => flattenTimeline(TIMELINE_DATA.timeline), []);
+  const items = useMemo<FlattenedItem[]>(
+    () => flattenTimeline(TIMELINE_DATA.timeline),
+    [],
+  );
   const [showProjectDialog, setShowProjectDialog] = useState(false);
-  const [selectedProject, setSelectedProject] = useState(null);
+  const [selectedProject, setSelectedProject] = useState<FlattenedItem | null>(
+    null,
+  );
 
-  const handleProjectClick = (project) => {
+  const handleProjectClick = (project: FlattenedItem) => {
     setSelectedProject(project);
     setShowProjectDialog(true);
   };
@@ -25,33 +32,36 @@ export default function ProjectsGrid() {
       />
       <div className="mt-12 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
         {items.map((it, i) => (
-          <Card
+          <NeonGradientCard
             key={`${it.year}-${i}-${it.title}`}
             className={cn(
-              'transform-gpu cursor-pointer select-none rounded-xl p-3 ring-1 ring-white/10 transition-all hover:bg-white/5',
+              'relative cursor-pointer select-none rounded-xl p-5 transition-transform hover:scale-[1.02]',
             )}
             onClick={() => handleProjectClick(it)}
           >
-            <CardContent className="p-0">
-              <div className="text-left">
-                <div className="text-xs text-white/50">{it.year}</div>
-                <div className="font-medium">{it.title}</div>
-                <div className="text-xs text-white/60">
-                  {it.area && <span>{it.area}</span>}
-                  {it.kind && it.area && <span> · </span>}
-                  {it.kind && <span>{it.kind}</span>}
-                  {it.stack?.length ? (
-                    <>
-                      <span> · </span>
-                      <span className="text-white/50">
-                        {it.stack.slice(0, 3).join(', ')}
-                      </span>
-                    </>
-                  ) : null}
-                </div>
+            <Ripple className="opacity-40" />
+            <div className="relative z-10 flex flex-col gap-2 text-left">
+              <div className="flex items-center justify-between text-xs text-white/60">
+                <span>{it.year}</span>
+                {it.flag && <span className="text-lg leading-none">{it.flag}</span>}
               </div>
-            </CardContent>
-          </Card>
+              <div className="font-medium">{it.title}</div>
+              <div className="text-xs text-white/60">
+                {it.area && <span>{it.area}</span>}
+                {it.kind && it.area && <span> · </span>}
+                {it.kind && <span>{it.kind}</span>}
+              </div>
+              {it.stack?.length ? (
+                <div className="mt-1 flex flex-wrap gap-1">
+                  {it.stack.slice(0, 3).map((tech) => (
+                    <Badge key={tech} variant="outline">
+                      {tech}
+                    </Badge>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          </NeonGradientCard>
         ))}
       </div>
     </>

--- a/src/components/project-dialog.tsx
+++ b/src/components/project-dialog.tsx
@@ -6,44 +6,96 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { QuoteIcon } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Highlighter } from '@/components/magicui/highlighter';
+import { type FlattenedItem } from '@/lib/timeline';
+import { ExternalLink, QuoteIcon } from 'lucide-react';
 
-const ProjectDialog = ({ open, onOpenChange, project }) => {
+interface ProjectDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  project: FlattenedItem | null;
+}
+
+const ProjectDialog = ({ open, onOpenChange, project }: ProjectDialogProps) => {
   if (!project) return null;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent className="max-w-2xl">
         <DialogHeader>
-          <DialogTitle>{project.title}</DialogTitle>
+          <DialogTitle className="flex items-center gap-2 text-xl">
+            {project.flag && <span>{project.flag}</span>}
+            <Highlighter>{project.title}</Highlighter>
+          </DialogTitle>
+          <DialogDescription className="text-sm text-white/60">
+            {project.year}
+            {project.area && <span> · {project.area}</span>}
+            {project.kind && <span> · {project.kind}</span>}
+            {project.country && <span> · {project.country}</span>}
+          </DialogDescription>
         </DialogHeader>
-        <DialogDescription>
-          <div className="text-xs text-white/50">{project.year}</div>
-          <div className="text-xs text-white/60">
-            {project.area && <span>{project.area}</span>}
-            {project.kind && project.area && <span> · </span>}
-            {project.kind && <span>{project.kind}</span>}
-          </div>
-          <p className="mt-4">{project.description}</p>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed">
+          {project.summary && <p>{project.summary}</p>}
           {project.stack?.length ? (
-            <div className="mt-4">
-              <h4 className="font-medium">Stack:</h4>
-              <ul className="list-disc list-inside">
+            <div>
+              <h4 className="font-medium">Tech Stack</h4>
+              <div className="mt-1 flex flex-wrap gap-1">
                 {project.stack.map((tech) => (
-                  <li key={tech}>{tech}</li>
+                  <Badge key={tech} variant="outline">
+                    {tech}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          ) : null}
+          {project.objectives && project.objectives.length > 0 && (
+            <div>
+              <h4 className="font-medium">Objectives</h4>
+              <ul className="mt-1 list-disc list-inside space-y-1">
+                {project.objectives.map((obj) => (
+                  <li key={obj}>{obj}</li>
                 ))}
               </ul>
             </div>
-          ) : null}
-          {project.testimonial && (
-            <div className="mt-4">
-              <QuoteIcon className="h-5 w-5 text-blue-300" />
-              <blockquote className="mt-2 text-sm italic leading-relaxed text-white/80">
-                {project.testimonial}
-              </blockquote>
+          )}
+          {project.achievements && project.achievements.length > 0 && (
+            <div>
+              <h4 className="font-medium">Achievements</h4>
+              <ul className="mt-1 list-disc list-inside space-y-1">
+                {project.achievements.map((ach) => (
+                  <li key={ach}>{ach}</li>
+                ))}
+              </ul>
             </div>
           )}
-        </DialogDescription>
+          {project.links && project.links.length > 0 && (
+            <div>
+              <h4 className="font-medium">Links</h4>
+              <ul className="mt-1 space-y-1">
+                {project.links.map((link) => (
+                  <li key={link.href}>
+                    <a
+                      href={link.href}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex items-center gap-1 text-blue-400 hover:underline"
+                    >
+                      {link.label}
+                      <ExternalLink className="h-3 w-3" />
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {project.testimonial && (
+            <div className="border-l-2 border-white/20 pl-4 italic">
+              <QuoteIcon className="mb-1 h-4 w-4 text-blue-300" />
+              {project.testimonial}
+            </div>
+          )}
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -24,7 +24,7 @@ import {
 import { OssHighlights } from '@/sections/oss-highlights.tsx';
 import { TypingAnimation } from '@/components/magicui/typing-animation';
 import { Highlighter } from '@/components/magicui/highlighter.tsx';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import BlurFade from '@/components/magicui/blur-fade.tsx';
 import FunnyVirusScanDialog from '@/components/virus-scan-dialog.tsx';
 import JokeDialog from '@/components/joke-dialog.tsx';
@@ -35,6 +35,7 @@ import { useNavigate } from 'react-router-dom';
 import confetti from 'canvas-confetti';
 import ExperienceRoulette from '@/sections/experience-roulette.tsx';
 import { TESTIMONIALS, TIMELINE_DATA } from '@/data/timeline';
+import { flattenTimeline, type FlattenedItem } from '@/lib/timeline';
 import { Marquee } from '@/components/magicui/marquee';
 import ProjectDialog from '@/components/project-dialog';
 
@@ -43,7 +44,13 @@ export default function Home() {
   const [showVirusScan, setShowVirusScan] = useState(false);
   const [showJokeDialog, setShowJokeDialog] = useState(false);
   const [showProjectDialog, setShowProjectDialog] = useState(false);
-  const [selectedProject, setSelectedProject] = useState(null);
+  const [selectedProject, setSelectedProject] = useState<FlattenedItem | null>(
+    null,
+  );
+  const items = useMemo<FlattenedItem[]>(
+    () => flattenTimeline(TIMELINE_DATA.timeline),
+    [],
+  );
   const navigate = useNavigate();
   const typingDelay =
     mainPhrase.reduce((sum, s) => s.length + sum, 0) * 100 + 600;
@@ -109,10 +116,9 @@ export default function Home() {
   }
 
   const handleTestimonialClick = (testimonial) => {
-    const project = Object.values(TIMELINE_DATA.timeline)
-      .flat()
-      .find((item) => item.testimonial === testimonial.quote);
-
+    const project = items.find(
+      (item) => item.testimonial === testimonial.quote,
+    );
     if (project) {
       setSelectedProject(project);
       setShowProjectDialog(true);

--- a/src/sections/experience-roulette.tsx
+++ b/src/sections/experience-roulette.tsx
@@ -3,17 +3,27 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { TIMELINE_DATA } from '@/data/timeline';
-import { COUNTRY_COORDS, flattenTimeline, focusGlobe } from '@/lib/timeline';
+import {
+  COUNTRY_COORDS,
+  flattenTimeline,
+  focusGlobe,
+  type FlattenedItem,
+} from '@/lib/timeline';
 import TimelineGlobe from '@/components/timeline-globe';
 import { cn } from '@/lib/utils';
 import ProjectDialog from '@/components/project-dialog';
 
 export default function ExperienceRoulette() {
-  const items = useMemo(() => flattenTimeline(TIMELINE_DATA.timeline), []);
+  const items = useMemo<FlattenedItem[]>(
+    () => flattenTimeline(TIMELINE_DATA.timeline),
+    [],
+  );
   const listRef = useRef<HTMLUListElement>(null);
   const [active, setActive] = useState(0);
   const [showProjectDialog, setShowProjectDialog] = useState(false);
-  const [selectedProject, setSelectedProject] = useState(null);
+  const [selectedProject, setSelectedProject] = useState<FlattenedItem | null>(
+    null,
+  );
 
   // Observe the list’s own scroll to pick the item closest to the vertical center
   useEffect(() => {
@@ -59,7 +69,7 @@ export default function ExperienceRoulette() {
     };
   }, [items, active]);
 
-  const handleProjectClick = (project) => {
+  const handleProjectClick = (project: FlattenedItem) => {
     setSelectedProject(project);
     setShowProjectDialog(true);
   };


### PR DESCRIPTION
## Summary
- Revamp project cards with Magic UI styling, country flags, and stack badges
- Expand project dialog to showcase timeline metadata like objectives, achievements and external links
- Type timeline items for consistent dialog usage across pages

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb57b19c248331b9e51ed4bf28ef00