### PR TITLE
Persist hero animations across navigation

### DIFF
--- a/src/components/magicui/typing-animation.tsx
+++ b/src/components/magicui/typing-animation.tsx
@@ -11,6 +11,7 @@ interface TypingAnimationProps extends MotionProps {
   delay?: number;
   as?: React.ElementType;
   startOnView?: boolean;
+  disabled?: boolean;
 }
 
 export function TypingAnimation({
@@ -20,13 +21,16 @@ export function TypingAnimation({
   delay = 0,
   as: Component = 'div',
   startOnView = false,
+  disabled = false,
   ...props
 }: TypingAnimationProps) {
   const MotionComponent = motion.create(Component, {
     forwardMotionProps: true,
   });
 
-  const [displayedText, setDisplayedText] = useState<string>('');
+  const [displayedText, setDisplayedText] = useState<string>(
+    disabled ? children : '',
+  );
   const [started, setStarted] = useState(false);
   const elementRef = useRef<HTMLElement | null>(null);
   const isInView = useInView(elementRef as React.RefObject<Element>, {
@@ -35,6 +39,12 @@ export function TypingAnimation({
   });
 
   useEffect(() => {
+    if (disabled) setDisplayedText(children);
+  }, [children, disabled]);
+
+  useEffect(() => {
+    if (disabled) return;
+
     if (!startOnView) {
       const startTimeout = setTimeout(() => {
         setStarted(true);
@@ -49,10 +59,10 @@ export function TypingAnimation({
     }, delay);
 
     return () => clearTimeout(startTimeout);
-  }, [delay, startOnView, isInView]);
+  }, [delay, startOnView, isInView, disabled]);
 
   useEffect(() => {
-    if (!started) return;
+    if (disabled || !started) return;
 
     const graphemes = Array.from(children);
     let i = 0;
@@ -68,7 +78,7 @@ export function TypingAnimation({
     return () => {
       clearInterval(typingEffect);
     };
-  }, [children, duration, started]);
+  }, [children, duration, started, disabled]);
 
   return (
     <MotionComponent

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -36,19 +36,27 @@ import confetti from 'canvas-confetti';
 import ExperienceRoulette from '@/sections/experience-roulette.tsx';
 
 export default function Home() {
-  const [completed, setCompleted] = useState(false);
+  const hasSeenHero =
+    typeof window !== 'undefined' &&
+    sessionStorage.getItem('hasSeenHero') === 'true';
+
+  const [completed, setCompleted] = useState(hasSeenHero);
   const [showVirusScan, setShowVirusScan] = useState(false);
   const [showJokeDialog, setShowJokeDialog] = useState(false);
   const navigate = useNavigate();
   const typingDelay =
     mainPhrase.reduce((sum, s) => s.length + sum, 0) * 100 + 600;
+  const skipAnimation = hasSeenHero;
 
   useEffect(() => {
-    setTimeout(() => {
+    if (skipAnimation) return;
+    const timer = setTimeout(() => {
       setCompleted(true);
+      sessionStorage.setItem('hasSeenHero', 'true');
     }, typingDelay + 1500);
     return () => {
-      setCompleted(false);
+      clearTimeout(timer);
+      setCompleted(skipAnimation);
     };
     //eslint-disable-next-line
   }, []);
@@ -120,12 +128,16 @@ export default function Home() {
         />
         <div className="relative z-10 mx-auto flex w-full max-w-none flex-col items-center px-6">
           <div className="mx-auto max-w-4xl text-center h-60">
-            <TypingAnimation className="text-4xl font-semibold tracking-tight sm:text-6xl md:text-7xl">
+            <TypingAnimation
+              disabled={skipAnimation}
+              className="text-4xl font-semibold tracking-tight sm:text-6xl md:text-7xl"
+            >
               {mainPhrase[0]}
             </TypingAnimation>
 
             <TypingAnimation
-              delay={mainPhrase[0].length * 100}
+              disabled={skipAnimation}
+              delay={skipAnimation ? 0 : mainPhrase[0].length * 100}
               className="text-4xl font-semibold tracking-tight sm:text-6xl md:text-7xl"
             >
               {mainPhrase[1]}
@@ -134,10 +146,15 @@ export default function Home() {
               iterations={3}
               action={'underline'}
               inView={true}
-              delay={typingDelay}
+              delay={skipAnimation ? 0 : typingDelay}
             >
               <TypingAnimation
-                delay={(mainPhrase[0].length + mainPhrase[1].length) * 100}
+                disabled={skipAnimation}
+                delay={
+                  skipAnimation
+                    ? 0
+                    : (mainPhrase[0].length + mainPhrase[1].length) * 100
+                }
                 className="text-4xl font-semibold tracking-tight sm:text-6xl md:text-7xl"
               >
                 Can't


### PR DESCRIPTION
## Summary
- remember when the hero animations have been watched and skip them on return
- allow `TypingAnimation` to render instantly via a `disabled` prop
- wire the Home page hero to honor the stored flag

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b99d40122c8331906f7f85b4f42d13