### PR TITLE
feat: add animated project filters

### DIFF
--- a/src/components/ProjectsGrid.tsx
+++ b/src/components/ProjectsGrid.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
 import { TIMELINE_DATA } from '@/data/timeline';
 import { type FlattenedItem, flattenTimeline } from '@/lib/timeline';
 import { Badge } from '@/components/ui/badge';
@@ -15,6 +16,21 @@ export default function ProjectsGrid() {
   const [selectedProject, setSelectedProject] = useState<FlattenedItem | null>(
     null,
   );
+  const [filter, setFilter] = useState('All');
+
+  const categories = useMemo(() => {
+    const set = new Set<string>();
+    for (const it of items) if (it.area) set.add(it.area);
+    return Array.from(set).sort();
+  }, [items]);
+
+  const filteredItems = useMemo(
+    () =>
+      filter === 'All'
+        ? items
+        : items.filter((it) => it.area === filter),
+    [items, filter],
+  );
 
   const handleProjectClick = (project: FlattenedItem) => {
     setSelectedProject(project);
@@ -28,41 +44,73 @@ export default function ProjectsGrid() {
         onOpenChange={setShowProjectDialog}
         project={selectedProject}
       />
-      <div className="mt-12 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-        {items.map((it, i) => (
-          <div
-            key={`${it.year}-${i}-${it.title}`}
-            className={cn(
-              'relative cursor-pointer select-none rounded-xl p-5 transition-transform hover:scale-[1.02]',
-            )}
-            onClick={() => handleProjectClick(it)}
+      <div className="mt-12 w-full">
+        <div className="flex flex-wrap justify-center gap-2">
+          <Badge
+            variant={filter === 'All' ? 'secondary' : 'outline'}
+            onClick={() => setFilter('All')}
+            className="cursor-pointer"
           >
-            <Ripple className="opacity-40" />
-            <div className="relative z-10 flex flex-col gap-2 text-left">
-              <div className="flex items-center justify-between text-xs text-white/60">
-                <span>{it.year}</span>
-                {it.flag && (
-                  <span className="text-lg leading-none">{it.flag}</span>
+            All
+          </Badge>
+          {categories.map((cat) => (
+            <Badge
+              key={cat}
+              variant={filter === cat ? 'secondary' : 'outline'}
+              onClick={() => setFilter(cat)}
+              className="cursor-pointer"
+            >
+              {cat}
+            </Badge>
+          ))}
+        </div>
+        <motion.div
+          layout
+          className="mt-8 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3"
+        >
+          <AnimatePresence>
+            {filteredItems.map((it) => (
+              <motion.div
+                layout
+                key={it.index}
+                initial={{ opacity: 0, scale: 0.9 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.9 }}
+                transition={{ duration: 0.2 }}
+                whileHover={{ scale: 1.02 }}
+                className={cn(
+                  'relative cursor-pointer select-none rounded-xl p-5 transition-transform',
                 )}
-              </div>
-              <div className="font-medium">{it.title}</div>
-              <div className="text-xs text-white/60">
-                {it.area && <span>{it.area}</span>}
-                {it.kind && it.area && <span> · </span>}
-                {it.kind && <span>{it.kind}</span>}
-              </div>
-              {it.stack?.length ? (
-                <div className="mt-1 flex flex-wrap gap-1">
-                  {it.stack.slice(0, 3).map((tech) => (
-                    <Badge key={tech} variant="outline">
-                      {tech}
-                    </Badge>
-                  ))}
+                onClick={() => handleProjectClick(it)}
+              >
+                <Ripple className="opacity-40" />
+                <div className="relative z-10 flex flex-col gap-2 text-left">
+                  <div className="flex items-center justify-between text-xs text-white/60">
+                    <span>{it.year}</span>
+                    {it.flag && (
+                      <span className="text-lg leading-none">{it.flag}</span>
+                    )}
+                  </div>
+                  <div className="font-medium">{it.title}</div>
+                  <div className="text-xs text-white/60">
+                    {it.area && <span>{it.area}</span>}
+                    {it.kind && it.area && <span> · </span>}
+                    {it.kind && <span>{it.kind}</span>}
+                  </div>
+                  {it.stack?.length ? (
+                    <div className="mt-1 flex flex-wrap gap-1">
+                      {it.stack.slice(0, 3).map((tech) => (
+                        <Badge key={tech} variant="outline">
+                          {tech}
+                        </Badge>
+                      ))}
+                    </div>
+                  ) : null}
                 </div>
-              ) : null}
-            </div>
-          </div>
-        ))}
+              </motion.div>
+            ))}
+          </AnimatePresence>
+        </motion.div>
       </div>
     </>
   );

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -1,6 +1,7 @@
 
 import { Footer } from '@/sections/footer';
 import ProjectsGrid from '@/components/ProjectsGrid';
+import { Badge } from '@/components/ui/badge';
 
 export default function Projects() {
   return (
@@ -8,6 +9,9 @@ export default function Projects() {
       <section id="projects" className="relative py-24">
         <div className="relative z-10 mx-auto flex w-full max-w-none flex-col items-center px-6">
           <div className="mx-auto max-w-4xl text-center">
+            <Badge variant="secondary" className="mb-4 text-sm font-mono">
+              /projects
+            </Badge>
             <h1 className="text-4xl font-semibold tracking-tight sm:text-6xl md:text-7xl">
               Projects
             </h1>


### PR DESCRIPTION
## Summary
- add `/projects` badge to page header
- add category filters with framer-motion animations

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc5e0109508331944157f3d3ded246